### PR TITLE
[VSIM-14] remove security-constraint for the REST-API for VSim 

### DIFF
--- a/dspace-rest/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-rest/src/main/webapp/WEB-INF/web.xml
@@ -58,17 +58,6 @@
         <url-pattern>/static/*</url-pattern>
     </servlet-mapping>
 
-    <!-- Security settings and mapping -->
-    <security-constraint>
-        <web-resource-collection>
-            <web-resource-name>DSpace REST API</web-resource-name>
-            <url-pattern>/*</url-pattern>
-        </web-resource-collection>
-        <user-data-constraint>
-            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
-        </user-data-constraint>
-    </security-constraint>
-    
     <!-- ConfigurationService initialization for dspace.dir -->
     <context-param>
         <description>


### PR DESCRIPTION
We use HA Proxy to do SSL, not Tomcat, this constraint is not necessary and causes problems.