### PR TITLE
Vsim 73 item curation script

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -119,280 +119,39 @@ public class VSimItemCurationTask extends AbstractCurationTask
 
               // TODO: find the corresponding project master item for all items in this collection
               // first, grab the collection object for this item
-              // - ItemService has this method: public List<Collection> getCollectionsNotLinked(Context context, Item item) throws SQLException;
               List<Collection> thisItemCollection = itemService.getCollectionsNotLinked(Curator.curationContext(), item);
 
               // then grab the vsim.relation.projectMaster metadata
 
-
+              // assume that the first collection returned above is the one we want (there should only be one)
               // then copy the collection links from the projectMaster item to this item
+              List<MetadataValue> mvProjectMaster = collectionService.getMetadata(thisItemCollection.get(0), "vsim", "relation", "projectMaster", Item.ANY);
 
+              String projectMasterHandle = mvProjectMaster.get(0).getValue();
 
+              // get the collection links from the project master item
+              DSpaceObject projectMasterDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterHandle);
+              Item projectMasterItem = (Item) projectMasterDSO;
 
+              List<MetadataValue> mvVsimMasterRelationCommunity = itemService.getMetadata(projectMasterItem, "vsim", "relation", "community", Item.ANY);
+              List<MetadataValue> mvVsimMasterRelationModels = itemService.getMetadata(projectMasterItem, "vsim", "relation", "models", Item.ANY);
+              List<MetadataValue> mvVsimMasterRelationArchives = itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY);
+              List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
+              // set the relation values to the projectMaster values gathered above
+              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "community", Item.ANY, mvVsimMasterRelationCommunity.get(0).getValue());
+              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY, mvVsimMasterRelationModels.get(0).getValue());
+              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY, mvVsimMasterRelationArchives.get(0).getValue());
+              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY, mvVsimMasterRelationSubmissions.get(0).getValue());
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-              // this is all copied code beyond this point, use for inspiration, when the script is written above, delete everything below here VVVV
-
-              // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
-              // use the usual list stuff to manage multiple values
-
-              String itemId = item.getHandle();
-              List<MetadataValue> mvDcTitle = itemService.getMetadata(item, "dc", "title", Item.ANY, Item.ANY);
-              List<MetadataValue> mvDcDescriptionAbstract = itemService.getMetadata(item, "dc", "description", "abstract", Item.ANY);
-              List<MetadataValue> mvDcDescription = itemService.getMetadata(item, "dc", "description", Item.ANY, Item.ANY);
-              List<MetadataValue> mvDcRelation = itemService.getMetadata(item, "dc", "relation", Item.ANY, Item.ANY);
-              List<MetadataValue> mvDcDateCreated = itemService.getMetadata(item, "dc", "date", "created", Item.ANY);
-              List<MetadataValue> mvDcDescriptionSponsorship = itemService.getMetadata(item, "dc", "description", "sponsorship", Item.ANY);
-              List<MetadataValue> mvDcCoverageSpatial = itemService.getMetadata(item, "dc", "coverage", "spatial", Item.ANY);
-              List<MetadataValue> mvDcCoverageTemporal = itemService.getMetadata(item, "dc", "coverage", "temporal", Item.ANY);
-              List<MetadataValue> mvDcContributorAuthor = itemService.getMetadata(item, "dc", "", "contributor", "author", Item.ANY);
-              List<MetadataValue> mvDcContributor = itemService.getMetadata(item, "dc", "", "contributor", Item.ANY, Item.ANY);
-              List<MetadataValue> mvDcContributorAdvisor = itemService.getMetadata(item, "dc", "", "contributor", "advisor", Item.ANY);
-              List<MetadataValue> mvDcDescriptionURI = itemService.getMetadata(item, "dc", "description", "uri", Item.ANY);
-              List<MetadataValue> mvDcDateAvailable = itemService.getMetadata(item, "dc", "date", "available", Item.ANY);
-              List<MetadataValue> mvDcRightsHolder = itemService.getMetadata(item, "dc", "rights", "holder", Item.ANY);
-              List<MetadataValue> mvDcDateCopyright = itemService.getMetadata(item, "dc", "date", "copyright", Item.ANY);
-              List<MetadataValue> mvDcRights = itemService.getMetadata(item, "dc", "rights", Item.ANY, Item.ANY);
-              List<MetadataValue> mvDcDateIssued = itemService.getMetadata(item, "dc", "date", "issued", Item.ANY);
-              List<MetadataValue> mvVsimResearchObjective = itemService.getMetadata(item, "vsim", "research", "objective", Item.ANY);
-              List<MetadataValue> mvVsimAcknowledgements = itemService.getMetadata(item, "vsim", "acknowledgements", Item.ANY, Item.ANY);
-              List<MetadataValue> mvVsimBibliography = itemService.getMetadata(item, "vsim", "bibliography", Item.ANY, Item.ANY);
-              List<MetadataValue> mvVsimKeywords = itemService.getMetadata(item, "vsim", "keywords", Item.ANY, Item.ANY);
-              List<MetadataValue> mvVsimContributorDetails = itemService.getMetadata(item, "vsim", "contributor", "details", Item.ANY);
-              List<MetadataValue> mvVsimNews = itemService.getMetadata(item, "vsim", "news", Item.ANY, Item.ANY);
-
-              // the following are used as links and to give this Curation Task idempotency
-              List<MetadataValue> mvVsimRelationCommunity = itemService.getMetadata(item, "vsim", "relation", "community", Item.ANY);
-              List<MetadataValue> mvVsimRelationModels = itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY);
-              List<MetadataValue> mvVsimRelationArchives = itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY);
-              List<MetadataValue> mvVsimRelationSubmissions = itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY);
-
-              // TODO: MAKE THIS IDEMPOTENT!!!
-              // TODO: grab the projectCommunity in the same way I do on line 80, for projectMasterCollection, using HandleService, feeding it mvVsimRelationCommunity
-              // TODO: grab the mvVsimRelationCommunity, confirm it's not null/empty
-              // TODO: confirm that the dso for this handle exists and is a community object
-              // -- disabled for now, hjp, the below is not fully cooked, it's just a start, do all of the above
-              // if ( CollectionUtils.isNotEmpty(mvVsimRelationCommunity) ){
-                // create a new top level community for this project
-                Community projectCommunity = communityService.create(null, Curator.curationContext());
-              //} else {
-                // grab the linked projectCommunity by its handle
-                //Community projectCommunity = communityService.create(null, Curator.curationContext());
-              //}
-
-              // set what metadata we can on this community; this should be safe to re-run over existing communities... in that case the project master
-              // will simply overwrite whatever metadata is set on the existing community
-              // code is borrowed from the example here: https://github.com/DSpace/DSpace/blob/ea642d6c9289d96b37b5de3bb7a4863ec48eaa9c/dspace-api/src/test/java/org/dspace/content/packager/PackageUtilsTest.java#L79-L80
-
-              // set the title (dc.title)
-              if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
-                communityService.addMetadata(Curator.curationContext(), projectCommunity, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue());
-              }
-              // set the description (dc.description)
-              // TODO: this will likely require a combination of the following metatdata fields, with a bit of formatting added: dc.description, vsim.acknowledgements, vsim.research.objective
-              // TODO: support markup for any of these fields, will probably need to use a markdown library, like es.nitaur.markdown/txtmark or sirthius/pegdown
-              if ( CollectionUtils.isNotEmpty(mvDcDescription) ) {
-                communityService.addMetadata(Curator.curationContext(), projectCommunity, MetadataSchema.DC_SCHEMA, "description", null, null, mvDcDescription.get(0).getValue());
-              }
-
-              // set the short_description (dc.description.abstract)
-              if ( CollectionUtils.isNotEmpty(mvDcDescriptionAbstract) ) {
-                communityService.addMetadata(Curator.curationContext(), projectCommunity, MetadataSchema.DC_SCHEMA, "description", "abstract", null, mvDcDescriptionAbstract.get(0).getValue());
-              }
-
-              // TODO: set the sidebar_text (dc.description.tableofcontents) we'll have to interpolate this from other values, requires discussion and/or thought
-              // probably it'll be a link to the project master? leave blank for now, oh, or maybe the bibliography?
-
-              // set the copyright_text (dc.rights)
-              if ( CollectionUtils.isNotEmpty(mvDcRights) ) {
-                communityService.addMetadata(Curator.curationContext(), projectCommunity, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-              }
-
-              // finish the update of the projectCommunity metadata (AKA: write!)
-              communityService.update(Curator.curationContext(), projectCommunity);
-
-              // snag the projectCommunityhandle, we'll need it
-              String projectCommunityHandle = projectCommunity.getHandle();
-
-              // set the logo for the community, if possible, use projectCommunity.setLogo(Bitstream logo)
-
-              // We need a DSpace group object for AuthZ purposes, for ContentCreators, to keep handy
-              Group ContentCreatorsGroupObj = groupService.findByName(Curator.curationContext(), "Content Creators");
-              Group AnonymousGroupObj = groupService.findByName(Curator.curationContext(), "Anonymous");
-
-              // create the Administrators group we need
-              Group projectCommunityAdminGroupObj = communityService.createAdministrators(Curator.curationContext(), projectCommunity);
-
-              // add the ContentCreatorsGroupObj to the group we just created
-              groupService.addMember(Curator.curationContext(), projectCommunityAdminGroupObj, ContentCreatorsGroupObj);
-              groupService.update(Curator.curationContext(), projectCommunityAdminGroupObj);
-
-              // add a link to the top level community as metadata for this project master Item (use vsim.relation.community)
-              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "community", Item.ANY, projectCommunityHandle);
-
-              // if there is no link to the project models collection in this item's metadata, create a models collection in this project's TLC and add a link to the models collection as metadata for this project master item
-              Collection projectCollModels = collectionService.create(Curator.curationContext(), projectCommunity);
-              if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
-                collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue() + ": VSim Files");
-                collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", null, null, "Files specific to VSim, including 3D models, narratives, and embedded resources (e.g., .vsim, .nar, .ere). For the " + mvDcTitle.get(0).getValue() + " project.");
-                collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Files specific to VSim, including 3D models, narratives, and embedded resources (e.g., .vsim, .nar, .ere). For the " + mvDcTitle.get(0).getValue() + " project.");
-                collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", "tableofcontents", null, "Collection sidebar for Models: " + mvDcTitle.get(0).getValue());
-                collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-              }
-
-              // create the Administrators and Submitters groups we need
-              Group projectCollModelsAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollModels);
-              Group projectCollModelsSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollModels);
-
-              // add the ContentCreatorsGroupObj to the groups we just created
-              groupService.addMember(Curator.curationContext(), projectCollModelsAdminGroupObj, ContentCreatorsGroupObj);
-              groupService.addMember(Curator.curationContext(), projectCollModelsSubmittersGroupObj, ContentCreatorsGroupObj);
-              groupService.update(Curator.curationContext(), projectCollModelsAdminGroupObj);
-              groupService.update(Curator.curationContext(), projectCollModelsSubmittersGroupObj);
-
-              // write this collection
-              collectionService.update(Curator.curationContext(), projectCollModels);
-              // add a link to this collection to the item
-              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY, projectCollModels.getHandle() );
+…	            // update the itemService to write the values we just set
               itemService.update(Curator.curationContext(), item);
-
-              // if there is no link to the project archives collection in this item's metadata, create an archives collection in this project's TLC and add a link to the archives collection as metadata for this project master item
-              Collection projectCollArchives = collectionService.create(Curator.curationContext(), projectCommunity);
-              if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
-                collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue() + ": Project Archive");
-                collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", null, null, "Multimedia files related to the project that provide context for the 3D model (e.g., .pdf, .jpg, .ppt, .csv, etc.). For the " + mvDcTitle.get(0).getValue() + " project.");
-                collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Multimedia files related to the project that provide context for the 3D model (e.g., .pdf, .jpg, .ppt, .csv, etc.). For the " + mvDcTitle.get(0).getValue() + " project.");
-                collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", "tableofcontents", null, "Collection sidebar for Archives: " + mvDcTitle.get(0).getValue());
-                collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-              }
-
-              // create the Administrators and Submitters groups we need
-              Group projectCollArchivesAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollArchives);
-              Group projectCollArchivesSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollArchives);
-
-              // add the ContentCreatorsGroupObj to the groups we just created
-              groupService.addMember(Curator.curationContext(), projectCollArchivesAdminGroupObj, ContentCreatorsGroupObj);
-              groupService.addMember(Curator.curationContext(), projectCollArchivesSubmittersGroupObj, ContentCreatorsGroupObj);
-              groupService.update(Curator.curationContext(), projectCollArchivesAdminGroupObj);
-              groupService.update(Curator.curationContext(), projectCollArchivesSubmittersGroupObj);
-
-              // write this collection
-              collectionService.update(Curator.curationContext(), projectCollArchives);
-              // add a link to this collection to the item
-              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY, projectCollArchives.getHandle() );
-              itemService.update(Curator.curationContext(), item);
-
-              // if there is no link to the project submissions collection in this item's metadata, create a submissions collection in this project's TLC and add a link to the submissions collection as metadata for this project master item
-              Collection projectCollSubmissions = collectionService.create(Curator.curationContext(), projectCommunity);
-              if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
-                collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue() + ": User Submissions");
-                collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", null, null, "Multimedia files submitted by users for sharing within the educational and research communities (e.g., narratives created for use in the classroom, or imagery and texts related to the 3D model that are in the public domain). For the " + mvDcTitle.get(0).getValue() + " project.");
-                collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Multimedia files submitted by users for sharing within the educational and research communities (e.g., narratives created for use in the classroom, or imagery and texts related to the 3D model that are in the public domain). For the " + mvDcTitle.get(0).getValue() + " project.");
-                collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", "tableofcontents", null, "Collection sidebar for Submissions: " + mvDcTitle.get(0).getValue());
-                collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-              }
-
-              // create the Administrators and Submitters groups we need
-              Group projectCollSubmissionsAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollSubmissions);
-              Group projectCollSubmissionsSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollSubmissions);
-
-              // add the ContentCreatorsGroupObj to the admin group we just created, and the AnonymousGroupObj to the submitters group we just created
-              groupService.addMember(Curator.curationContext(), projectCollSubmissionsAdminGroupObj, ContentCreatorsGroupObj);
-              groupService.addMember(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj, AnonymousGroupObj);
-              groupService.update(Curator.curationContext(), projectCollSubmissionsAdminGroupObj);
-              groupService.update(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj);
-
-              // write this collection
-              collectionService.update(Curator.curationContext(), projectCollSubmissions);
-              // add a link to this collection to the item
-              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY, projectCollSubmissions.getHandle() );
-              itemService.update(Curator.curationContext(), item);
-
-              // update the projectCommunity (just to be safe)
-              communityService.update(Curator.curationContext(), projectCommunity);
-
-
-              // be sure to write the changed item metadata (just in case we've missed something along the way)
-              itemService.update(Curator.curationContext(), item);
-
-              // BEGIN: ADD LOGO to Community and Collections ///////////////////////////////////////////////////////////////////////////////
-              // Get the list of Bitstreams for this Project Master item
-              List<Bitstream> projectMasterBitstreams = itemService.getNonInternalBitstreams(Curator.curationContext(), item);
-
-              // Now do something useful with these bitstreams:
-              // Loop through each bistream, find the logo, get the path, send that path to the addlogo method for all generated communities and collections
-              // NOTE: this bakes in the assumption that this bitstream lives on the same server, and thus has a file path that this curation script can reference, which is not guaranteed
-              // by DSpace. Still, good enough for now, as this assumption works for our current implementation.
-
-              for (Bitstream bitstream : projectMasterBitstreams) {
-                  String fileNameWithOutExt = FilenameUtils.removeExtension(bitstream.getName());
-                  if ("logo".equals(fileNameWithOutExt)) {
-                      // infer the bitstream path by splitting the bitstream internal ID and adding it to the assetstore path
-                      // this is kind of dumb, but it's how the bitstore migration code does it
-                      String sInternalId = bitstream.getInternalId();
-                      String sIntermediatePath = null;
-                      sIntermediatePath = getIntermediatePath(sInternalId);
-                      StringBuilder bufFilename = new StringBuilder();
-                      bufFilename.append(assetstoreDir);
-                      bufFilename.append(File.separator);
-                      bufFilename.append(sIntermediatePath);
-                      bufFilename.append(sInternalId);
-
-                      // make an InputStream for this logo
-                      InputStream projectLogoFileStream4Community = new FileInputStream(bufFilename.toString());
-
-                      // load the logo bitstream into the community and collections created above
-                      communityService.setLogo(Curator.curationContext(), projectCommunity, projectLogoFileStream4Community);
-
-                      // update of the projectCommunity (AKA: write!)
-                      communityService.update(Curator.curationContext(), projectCommunity);
-
-                      // re-open the logoFileStream, the setLogo method closes it
-                      InputStream projectLogoFileStream4projectCollModels = new FileInputStream(bufFilename.toString());
-                      // load the logo bitstream into collectionService for projectCollModels
-                      collectionService.setLogo(Curator.curationContext(), projectCollModels, projectLogoFileStream4projectCollModels);
-
-                      // re-open the logoFileStream, the setLogo method closes it
-                      InputStream projectLogoFileStream4projectCollArchives = new FileInputStream(bufFilename.toString());
-                      // load the logo bitstream into collectionService for projectCollArchives
-                      collectionService.setLogo(Curator.curationContext(), projectCollArchives, projectLogoFileStream4projectCollArchives);
-
-                      // re-open the logoFileStream, the setLogo method closes it
-                      InputStream projectLogoFileStream4projectCollSubmissions = new FileInputStream(bufFilename.toString());
-                      // load the logo bitstream into collectionService for projectCollSubmissions
-                      collectionService.setLogo(Curator.curationContext(), projectCollSubmissions, projectLogoFileStream4projectCollSubmissions);
-
-                      // update each collection via collectionService for projectCollModels, projectCollArchives, projectCollSubmissions
-                      collectionService.update(Curator.curationContext(), projectCollModels);
-                      collectionService.update(Curator.curationContext(), projectCollArchives);
-                      collectionService.update(Curator.curationContext(), projectCollSubmissions);
-
-                  }
-              }
-
-              // END: ADD LOGO to Community and Collections ///////////////////////////////////////////////////////////////////////////////
-
-
-
 
               // set the success flag and add a line to the result report
               // KEEP THIS AT THE END OF THE SCRIPT
 
               status = Curator.CURATE_SUCCESS;
-              result = "VSim Project intialized based on " + itemId + " | title: " + mvDcTitle.get(0).getValue() + " | Project Community: " + projectCommunityHandle;
+              result = "VSim standard item " + itemId + " updated with metatdata from project master " + projectMasterHandle;
 
             // catch any exceptions
             } catch (AuthorizeException authE) {
@@ -402,34 +161,11 @@ public class VSimItemCurationTask extends AbstractCurationTask
         		log.error("caught exception: " + sqlE);
            	}
 
-
               setResult(result);
               report(result);
 		}
 
         return status;
-    }
-
-    /**
-     * Return the intermediate path derived from the internal_id. This method
-     * splits the id into groups which become subdirectories.
-     *
-     * @param iInternalId
-     *            The internal_id
-     * @return The path based on the id without leading or trailing separators
-     */
-    protected String getIntermediatePath(String iInternalId) {
-        StringBuilder buf = new StringBuilder();
-        for (int i = 0; i < directoryLevels; i++) {
-            int digits = i * digitsPerLevel;
-            if (i > 0) {
-                buf.append(File.separator);
-            }
-            buf.append(iInternalId.substring(digits, digits
-                    + digitsPerLevel));
-        }
-        buf.append(File.separator);
-        return buf.toString();
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -68,8 +68,8 @@ public class VSimItemCurationTask extends AbstractCurationTask
 
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
-    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
     protected int status = Curator.CURATE_UNSET;
     protected String result = null;
 
@@ -93,7 +93,6 @@ public class VSimItemCurationTask extends AbstractCurationTask
     // read some configuration settings
     //reference: ConfigurationService info: https://wiki.duraspace.org/display/DSPACE/DSpace+Spring+Services+Tutorial#DSpaceSpringServicesTutorial-DSpaceConfigurationService
     String projectMasterCollectionHandle = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("vsim.project.master.collection.handle");
-    String assetstoreDir = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("assetstore.dir");
 
     // if the projectMasterCollectionHandle value isn't set, use a default
     if (StringUtils.isEmpty(projectMasterCollectionHandle))
@@ -118,11 +117,15 @@ public class VSimItemCurationTask extends AbstractCurationTask
               break vsimItem;
           }
 
-              // TODO: find the corresponding project master item for all itmes in this collection
+              // TODO: find the corresponding project master item for all items in this collection
               // first, grab the collection object for this item
+              // - ItemService has this method: public List<Collection> getCollectionsNotLinked(Context context, Item item) throws SQLException;
+              List<Collection> thisItemCollection = itemService.getCollectionsNotLinked(Curator.curationContext(), item);
+
               // then grab the vsim.relation.projectMaster metadata
 
 
+              // then copy the collection links from the projectMaster item to this item
 
 
 
@@ -139,7 +142,9 @@ public class VSimItemCurationTask extends AbstractCurationTask
 
 
 
-              // this is all copied code beyond this point VVVV
+
+
+              // this is all copied code beyond this point, use for inspiration, when the script is written above, delete everything below here VVVV
 
               // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
               // use the usual list stuff to manage multiple values

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -65,7 +65,6 @@ public class VSimItemCurationTask extends AbstractCurationTask
 /** log4j category */
     private static final Logger log = Logger.getLogger(VSimProjectCurationTask.class);
 
-    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
@@ -136,13 +135,11 @@ public class VSimItemCurationTask extends AbstractCurationTask
               DSpaceObject projectMasterDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterHandle);
               Item projectMasterItem = (Item) projectMasterDSO;
 
-              List<MetadataValue> mvVsimMasterRelationCommunity = itemService.getMetadata(projectMasterItem, "vsim", "relation", "community", Item.ANY);
               List<MetadataValue> mvVsimMasterRelationModels = itemService.getMetadata(projectMasterItem, "vsim", "relation", "models", Item.ANY);
               List<MetadataValue> mvVsimMasterRelationArchives = itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY);
               List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
               // set the relation values to the projectMaster values gathered above
-              itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "community", Item.ANY, mvVsimMasterRelationCommunity.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY, mvVsimMasterRelationModels.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY, mvVsimMasterRelationArchives.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY, mvVsimMasterRelationSubmissions.get(0).getValue());

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -14,19 +14,13 @@ https://github.com/DSpace/DSpace/blob/ea642d6c9289d96b37b5de3bb7a4863ec48eaa9c/d
 package org.dspace.ctask.general;
 
 import java.util.List;
-import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang.StringUtils;
-
-import org.apache.commons.io.FilenameUtils;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.Collection;
-import org.dspace.content.MetadataSchema;
 import org.dspace.curate.AbstractCurationTask;
-import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -14,7 +14,6 @@ https://github.com/DSpace/DSpace/blob/ea642d6c9289d96b37b5de3bb7a4863ec48eaa9c/d
 package org.dspace.ctask.general;
 
 import java.util.List;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -25,31 +24,21 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.Collection;
-import org.dspace.content.Community;
 import org.dspace.content.MetadataSchema;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
 
-import org.dspace.eperson.factory.EPersonServiceFactory;
-import org.dspace.eperson.Group;
-import org.dspace.eperson.service.GroupService;
-
 import org.apache.log4j.Logger;
 
 import org.dspace.services.factory.DSpaceServicesFactory;
-
-import java.io.File;
 
 import org.dspace.content.MetadataValue;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.*;
-
-import java.io.InputStream;
-import java.io.FileInputStream;
 
 import java.sql.SQLException;
 import java.io.IOException;
@@ -70,9 +59,6 @@ public class VSimItemCurationTask extends AbstractCurationTask
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
     protected int status = Curator.CURATE_UNSET;
     protected String result = null;
-
-    private static final int digitsPerLevel = 2;
-    private static final int directoryLevels = 3;
 
     /**
      * Perform the curation task upon passed DSO

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -119,6 +119,8 @@ public class VSimItemCurationTask extends AbstractCurationTask
               break vsimItem;
           }
 
+              log.info("VSimItemCurationTask: processing item at handle: " + itemId);
+
               // TODO: find the corresponding project master item for all items in this collection
               // first, grab the collection object for this item
               List<Collection> thisItemCollection = itemService.getCollectionsNotLinked(Curator.curationContext(), item);
@@ -131,6 +133,8 @@ public class VSimItemCurationTask extends AbstractCurationTask
 
               String projectMasterHandle = mvProjectMaster.get(0).getValue();
 
+              log.info("VSimItemCurationTask: found the corresponding projectMaster handle: " + projectMasterHandle);
+
               // get the collection links from the project master item
               DSpaceObject projectMasterDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterHandle);
               Item projectMasterItem = (Item) projectMasterDSO;
@@ -139,12 +143,19 @@ public class VSimItemCurationTask extends AbstractCurationTask
               List<MetadataValue> mvVsimMasterRelationArchives = itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY);
               List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
+
               // set the relation values to the projectMaster values gathered above
+              log.info("VSimItemCurationTask:  - adding vsim.relation.models: " + mvVsimMasterRelationModels.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY, mvVsimMasterRelationModels.get(0).getValue());
+
+              log.info("VSimItemCurationTask:  - adding vsim.relation.archives: " + mvVsimMasterRelationArchives.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY, mvVsimMasterRelationArchives.get(0).getValue());
+
+              log.info("VSimItemCurationTask:  - adding vsim.relation.submissions: " + mvVsimMasterRelationSubmissions.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY, mvVsimMasterRelationSubmissions.get(0).getValue());
 
               // update the itemService to write the values we just set
+              log.info("VSimItemCurationTask: writing changes to item at handle: " + itemId);
               itemService.update(Curator.curationContext(), item);
 
               // set the success flag and add a line to the result report

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -8,15 +8,11 @@
 
  /*
 THE PLAN:
-[x] get the project metadata from the Project Master Item
-what fields are we going to use for the links we will be checking below?
-we talked about using dc.relation.ispartof and dc.relation.requires, but that's not expressive enough for what we need
-we need four new fields: vsim.relation.community, vsim.relation.models, vsim.relation.archives, vsim.relation.submissions
-ALL/some of these links *can* be added to the dc fields, too, but that's not really important to us right now.
-We need to add them to fields we can use to also recall the values in this script
+[] only run this script for items that are NOT project master items
+[] find the corresponding project master item using collection membership information on this item
+[] get the project metadata from the Project Master Item
+[] copy the vsim.relation links (to the project collections) from the project master item to this item
 */
-
-// TODO: make this whole thing Idempotent (see below for notes, around line 109)
 
 package org.dspace.ctask.general;
 
@@ -61,11 +57,11 @@ import java.sql.SQLException;
 import java.io.IOException;
 
 /**
- * VSimProjectCurationTask is a task that initializes a VSim Project structure, based on the metadata entered in a VSim Project Master item
+ * VSimItemCurationTask is a task that copies important vsim.relation metadata from a project master to an item
  *
  * @author hardyoyo
  */
-public class VSimProjectCurationTask extends AbstractCurationTask
+public class VSimItemCurationTask extends AbstractCurationTask
 {
 /** log4j category */
     private static final Logger log = Logger.getLogger(VSimProjectCurationTask.class);
@@ -107,7 +103,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
 
 
     // If this dso is an ITEM, proceed
-    vsimInit:
+    vsimItem:
 		if (dso.getType() == Constants.ITEM)
         {
           try {
@@ -117,17 +113,36 @@ public class VSimProjectCurationTask extends AbstractCurationTask
 
           Item item = (Item)dso;
 
-          // *ONLY* KEEP GOING IF THIS ITEM IS A PROJECT MASTER, OTHERWISE *STOP*!!
-          if (!itemService.isIn(item, projectMastersCollection)) {
-              break vsimInit;
+          // IF THIS ITEM IS A PROJECT MASTER, *STOP*!! OTHERWISE, CONTINUE...
+          if (itemService.isIn(item, projectMastersCollection)) {
+              break vsimItem;
           }
 
+              // TODO: find the corresponding project master item for all itmes in this collection
+              // first, grab the collection object for this item
+              // then grab the vsim.relation.projectMaster metadata
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+              // this is all copied code beyond this point VVVV
 
               // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
               // use the usual list stuff to manage multiple values
-
 
               String itemId = item.getHandle();
               List<MetadataValue> mvDcTitle = itemService.getMetadata(item, "dc", "title", Item.ANY, Item.ANY);
@@ -231,9 +246,6 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Files specific to VSim, including 3D models, narratives, and embedded resources (e.g., .vsim, .nar, .ere). For the " + mvDcTitle.get(0).getValue() + " project.");
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", "tableofcontents", null, "Collection sidebar for Models: " + mvDcTitle.get(0).getValue());
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-                // ADD A LINK TO BACK TO THE PROJECT MASTER ITEM
-                collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
-
               }
 
               // create the Administrators and Submitters groups we need
@@ -260,8 +272,6 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Multimedia files related to the project that provide context for the 3D model (e.g., .pdf, .jpg, .ppt, .csv, etc.). For the " + mvDcTitle.get(0).getValue() + " project.");
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", "tableofcontents", null, "Collection sidebar for Archives: " + mvDcTitle.get(0).getValue());
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-                // ADD A LINK TO BACK TO THE PROJECT MASTER ITEM
-                collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
               }
 
               // create the Administrators and Submitters groups we need
@@ -288,8 +298,6 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Multimedia files submitted by users for sharing within the educational and research communities (e.g., narratives created for use in the classroom, or imagery and texts related to the 3D model that are in the public domain). For the " + mvDcTitle.get(0).getValue() + " project.");
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", "tableofcontents", null, "Collection sidebar for Submissions: " + mvDcTitle.get(0).getValue());
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "rights", null, null, mvDcRights.get(0).getValue());
-                // ADD A LINK TO BACK TO THE PROJECT MASTER ITEM
-                collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
               }
 
               // create the Administrators and Submitters groups we need

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -83,12 +83,12 @@ public class VSimItemCurationTask extends AbstractCurationTask
      * @throws SQLException if SQL error
      */
 
-     @Override
-     public int perform(DSpaceObject dso) throws IOException
-     {
+    @Override
+    public int perform(DSpaceObject dso) throws IOException
+    {
          distribute(dso);
          return Curator.CURATE_SUCCESS;
-     }
+    }
 
     @Override
     protected void performItem(Item item) throws IOException

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -111,6 +111,7 @@ public class VSimItemCurationTask extends AbstractCurationTask
           Collection projectMastersCollection = (Collection) projectMastersDSO;
 
           Item item = (Item)dso;
+          String itemId = item.getHandle();
 
           // IF THIS ITEM IS A PROJECT MASTER, *STOP*!! OTHERWISE, CONTINUE...
           if (itemService.isIn(item, projectMastersCollection)) {
@@ -144,7 +145,7 @@ public class VSimItemCurationTask extends AbstractCurationTask
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY, mvVsimMasterRelationArchives.get(0).getValue());
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY, mvVsimMasterRelationSubmissions.get(0).getValue());
 
-…	            // update the itemService to write the values we just set
+              // update the itemService to write the values we just set
               itemService.update(Curator.curationContext(), item);
 
               // set the success flag and add a line to the result report

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -85,7 +85,6 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
     // read some configuration settings
     //reference: ConfigurationService info: https://wiki.duraspace.org/display/DSPACE/DSpace+Spring+Services+Tutorial#DSpaceSpringServicesTutorial-DSpaceConfigurationService
     String projectMasterCollectionHandle = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("vsim.project.master.collection.handle");
-    String assetstoreDir = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("assetstore.dir");
 
     // if the projectMasterCollectionHandle value isn't set, use a default
     if (StringUtils.isEmpty(projectMasterCollectionHandle))
@@ -156,7 +155,7 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
               // KEEP THIS AT THE END OF THE SCRIPT
 
               status = Curator.CURATE_SUCCESS;
-              result = "VSim Project Master item links intialized based on " + itemId + " | title: " + mvDcTitle.get(0).getValue() ;
+              result = "VSim Project Master item links intialized based on " + itemId;
 
             // catch any exceptions
             } catch (AuthorizeException authE) {

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -9,7 +9,6 @@
 package org.dspace.ctask.general;
 
 import java.util.List;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -21,15 +20,10 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
-import org.dspace.content.MetadataSchema;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
-
-import org.dspace.eperson.factory.EPersonServiceFactory;
-import org.dspace.eperson.Group;
-import org.dspace.eperson.service.GroupService;
 
 import org.apache.log4j.Logger;
 
@@ -63,12 +57,8 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
     protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
     protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
     protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
-    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
     protected int status = Curator.CURATE_UNSET;
     protected String result = null;
-
-    private static final int digitsPerLevel = 2;
-    private static final int directoryLevels = 3;
 
     /**
      * Perform the curation task upon passed DSO

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -120,6 +120,8 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
 
               // get the handle to this master item, we'll need it
               String itemId = item.getHandle();
+              log.info("VSimProjectAddMasterItemLinkCurationTask: processing master item at handle: " + itemId);
+
 
               // the following are used to find the containers to which we need to add the itemId
               List<MetadataValue> mvVsimRelationCommunity = itemService.getMetadata(item, "vsim", "relation", "community", Item.ANY);
@@ -139,11 +141,15 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
               Collection projectCollSubmissions = (Collection) projectCollSubmissionsDSO;
 
               // set the link back to the project master item for each container object we grabbed above
+              log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollModels at handle: " + projectCollModels.getHandle());
               collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
+              log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollArchives at handle: " + projectCollArchives.getHandle());
               collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
+              log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollSubmissions at handle: " + projectCollSubmissions.getHandle());
               collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
 
               // now write all that metadata with a set of updates
+              log.info("VSimProjectAddMasterItemLinkCurationTask: Writing changes to all three project collections for master item at handle: " + itemId);
               collectionService.update(Curator.curationContext(), projectCollModels);
               collectionService.update(Curator.curationContext(), projectCollArchives);
               collectionService.update(Curator.curationContext(), projectCollSubmissions);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -9,19 +9,13 @@
 package org.dspace.ctask.general;
 
 import java.util.List;
-import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang.StringUtils;
-
-import org.apache.commons.io.FilenameUtils;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
-import org.dspace.content.Bitstream;
 import org.dspace.content.Item;
 import org.dspace.content.Collection;
-import org.dspace.content.Community;
 import org.dspace.curate.AbstractCurationTask;
-import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
 
@@ -29,16 +23,11 @@ import org.apache.log4j.Logger;
 
 import org.dspace.services.factory.DSpaceServicesFactory;
 
-import java.io.File;
-
 import org.dspace.content.MetadataValue;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.*;
-
-import java.io.InputStream;
-import java.io.FileInputStream;
 
 import java.sql.SQLException;
 import java.io.IOException;
@@ -114,7 +103,6 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
 
 
               // the following are used to find the containers to which we need to add the itemId
-              List<MetadataValue> mvVsimRelationCommunity = itemService.getMetadata(item, "vsim", "relation", "community", Item.ANY);
               List<MetadataValue> mvVsimRelationModels = itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY);
               List<MetadataValue> mvVsimRelationArchives = itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY);
               List<MetadataValue> mvVsimRelationSubmissions = itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -131,8 +131,6 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
               // -- the HandleService has resolveToObject(Context context, String handle) which goes from handle to dso
               // -- NOTE: this is a generic dso, not a typed dso (i.e. not a community or collection object)
               // -- just look at the code starting around line 103, there's an example there
-              DSpaceObject projectCommunityDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationCommunity.get(0).getValue());
-              Community projectCommunity = (Community) projectCommunityDSO;
               DSpaceObject projectCollModelsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationModels.get(0).getValue());
               Collection projectCollModels = (Collection) projectCollModelsDSO;
               DSpaceObject projectCollArchivesDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationArchives.get(0).getValue());
@@ -141,18 +139,14 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
               Collection projectCollSubmissions = (Collection) projectCollSubmissionsDSO;
 
               // set the link back to the project master item for each container object we grabbed above
-              communityService.addMetadata(Curator.curationContext(), projectCommunity, "vsim", "relation", "projectMaster", null, itemId);
               collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
               collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
               collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
 
               // now write all that metadata with a set of updates
-              communityService.update(Curator.curationContext(), projectCommunity);
               collectionService.update(Curator.curationContext(), projectCollModels);
               collectionService.update(Curator.curationContext(), projectCollArchives);
               collectionService.update(Curator.curationContext(), projectCollSubmissions);
-
-
 
               // set the success flag and add a line to the result report
               // KEEP THIS AT THE END OF THE SCRIPT

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -25,6 +25,7 @@ import org.dspace.content.MetadataSchema;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
 
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.Group;
@@ -53,6 +54,7 @@ import java.io.IOException;
  *
  * @author hardyoyo
  */
+@Distributive
 public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTask
 {
 /** log4j category */
@@ -76,9 +78,16 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
      * @throws SQLException if SQL error
      */
 
-    @Override
-    public int perform(DSpaceObject dso) throws IOException
-    {
+     @Override
+     public int perform(DSpaceObject dso) throws IOException
+     {
+          distribute(dso);
+          return Curator.CURATE_SUCCESS;
+     }
+
+     @Override
+     protected void performItem(Item item) throws IOException
+     {
 
     int status = Curator.CURATE_SKIP;
 
@@ -95,22 +104,16 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
 
     // If this dso is an ITEM, proceed
     vsimInit:
-		if (dso.getType() == Constants.ITEM)
-        {
+
           try {
 
           DSpaceObject projectMastersDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterCollectionHandle);
           Collection projectMastersCollection = (Collection) projectMastersDSO;
 
-          Item item = (Item)dso;
-
           // *ONLY* KEEP GOING IF THIS ITEM IS A PROJECT MASTER, OTHERWISE *STOP*!!
           if (!itemService.isIn(item, projectMastersCollection)) {
               break vsimInit;
           }
-
-
-
 
               // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
               // use the usual list stuff to manage multiple values
@@ -168,9 +171,7 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
 
               setResult(result);
               report(result);
-		}
 
-        return status;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -1,0 +1,177 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.ctask.general;
+
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.ListUtils;
+import org.apache.commons.lang.StringUtils;
+
+import org.apache.commons.io.FilenameUtils;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Item;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.MetadataSchema;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.core.Constants;
+import org.dspace.curate.Curator;
+
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.service.GroupService;
+
+import org.apache.log4j.Logger;
+
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+import java.io.File;
+
+import org.dspace.content.MetadataValue;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.*;
+
+import java.io.InputStream;
+import java.io.FileInputStream;
+
+import java.sql.SQLException;
+import java.io.IOException;
+
+/**
+ * VSimProjectAddMasterItemLinkCurationTask is a task that adds a link back to the project master item to the collections created by the ProjectMasterInit script
+ *
+ * @author hardyoyo
+ */
+public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTask
+{
+/** log4j category */
+    private static final Logger log = Logger.getLogger(VSimProjectCurationTask.class);
+
+    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+    protected int status = Curator.CURATE_UNSET;
+    protected String result = null;
+
+    private static final int digitsPerLevel = 2;
+    private static final int directoryLevels = 3;
+
+    /**
+     * Perform the curation task upon passed DSO
+     *
+     * @param dso the DSpace object
+     * @throws IOException if IO error
+     * @throws SQLException if SQL error
+     */
+
+    @Override
+    public int perform(DSpaceObject dso) throws IOException
+    {
+
+    int status = Curator.CURATE_SKIP;
+
+    // read some configuration settings
+    //reference: ConfigurationService info: https://wiki.duraspace.org/display/DSPACE/DSpace+Spring+Services+Tutorial#DSpaceSpringServicesTutorial-DSpaceConfigurationService
+    String projectMasterCollectionHandle = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("vsim.project.master.collection.handle");
+    String assetstoreDir = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("assetstore.dir");
+
+    // if the projectMasterCollectionHandle value isn't set, use a default
+    if (StringUtils.isEmpty(projectMasterCollectionHandle))
+      {
+        projectMasterCollectionHandle = "20.500.11930/1015"; // <-- that better be a collection object on that handle
+      }
+
+
+    // If this dso is an ITEM, proceed
+    vsimInit:
+		if (dso.getType() == Constants.ITEM)
+        {
+          try {
+
+          DSpaceObject projectMastersDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterCollectionHandle);
+          Collection projectMastersCollection = (Collection) projectMastersDSO;
+
+          Item item = (Item)dso;
+
+          // *ONLY* KEEP GOING IF THIS ITEM IS A PROJECT MASTER, OTHERWISE *STOP*!!
+          if (!itemService.isIn(item, projectMastersCollection)) {
+              break vsimInit;
+          }
+
+
+
+
+              // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
+              // use the usual list stuff to manage multiple values
+
+              // get the handle to this master item, we'll need it
+              String itemId = item.getHandle();
+
+              // the following are used to find the containers to which we need to add the itemId
+              List<MetadataValue> mvVsimRelationCommunity = itemService.getMetadata(item, "vsim", "relation", "community", Item.ANY);
+              List<MetadataValue> mvVsimRelationModels = itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY);
+              List<MetadataValue> mvVsimRelationArchives = itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY);
+              List<MetadataValue> mvVsimRelationSubmissions = itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY);
+
+              // grab each container object using the handles above
+              // -- the HandleService has resolveToObject(Context context, String handle) which goes from handle to dso
+              // -- NOTE: this is a generic dso, not a typed dso (i.e. not a community or collection object)
+              // -- just look at the code starting around line 103, there's an example there
+              DSpaceObject projectCommunityDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationCommunity.get(0).getValue());
+              Community projectCommunity = (Community) projectCommunityDSO;
+              DSpaceObject projectCollModelsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationModels.get(0).getValue());
+              Collection projectCollModels = (Collection) projectCollModelsDSO;
+              DSpaceObject projectCollArchivesDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationArchives.get(0).getValue());
+              Collection projectCollArchives = (Collection) projectCollArchivesDSO;
+              DSpaceObject projectCollSubmissionsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationSubmissions.get(0).getValue());
+              Collection projectCollSubmissions = (Collection) projectCollSubmissionsDSO;
+
+              // set the link back to the project master item for each container object we grabbed above
+              communityService.addMetadata(Curator.curationContext(), projectCommunity, "vsim", "relation", "projectMaster", null, itemId);
+              collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
+              collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
+              collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
+
+              // now write all that metadata with a set of updates
+              communityService.update(Curator.curationContext(), projectCommunity);
+              collectionService.update(Curator.curationContext(), projectCollModels);
+              collectionService.update(Curator.curationContext(), projectCollArchives);
+              collectionService.update(Curator.curationContext(), projectCollSubmissions);
+
+
+
+              // set the success flag and add a line to the result report
+              // KEEP THIS AT THE END OF THE SCRIPT
+
+              status = Curator.CURATE_SUCCESS;
+              result = "VSim Project Master item links intialized based on " + itemId + " | title: " + mvDcTitle.get(0).getValue() ;
+
+            // catch any exceptions
+            } catch (AuthorizeException authE) {
+        		log.error("caught exception: " + authE);
+        		status = Curator.CURATE_FAIL;
+           	} catch (SQLException sqlE) {
+        		log.error("caught exception: " + sqlE);
+           	}
+
+
+              setResult(result);
+              report(result);
+		}
+
+        return status;
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
@@ -37,6 +37,7 @@ import org.dspace.content.MetadataSchema;
 import org.dspace.curate.AbstractCurationTask;
 import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
 
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.Group;
@@ -65,6 +66,7 @@ import java.io.IOException;
  *
  * @author hardyoyo
  */
+@Distributive
 public class VSimProjectCurationTask extends AbstractCurationTask
 {
 /** log4j category */
@@ -88,9 +90,16 @@ public class VSimProjectCurationTask extends AbstractCurationTask
      * @throws SQLException if SQL error
      */
 
-    @Override
-    public int perform(DSpaceObject dso) throws IOException
-    {
+     @Override
+     public int perform(DSpaceObject dso) throws IOException
+     {
+          distribute(dso);
+          return Curator.CURATE_SUCCESS;
+     }
+
+     @Override
+     protected void performItem(Item item) throws IOException
+     {
 
     int status = Curator.CURATE_SKIP;
 
@@ -106,16 +115,12 @@ public class VSimProjectCurationTask extends AbstractCurationTask
       }
 
 
-    // If this dso is an ITEM, proceed
     vsimInit:
-		if (dso.getType() == Constants.ITEM)
-        {
+
           try {
 
           DSpaceObject projectMastersDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterCollectionHandle);
           Collection projectMastersCollection = (Collection) projectMastersDSO;
-
-          Item item = (Item)dso;
 
           // *ONLY* KEEP GOING IF THIS ITEM IS A PROJECT MASTER, OTHERWISE *STOP*!!
           if (!itemService.isIn(item, projectMastersCollection)) {
@@ -392,9 +397,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
 
               setResult(result);
               report(result);
-		}
 
-        return status;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
@@ -174,7 +174,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 // create a new top level community for this project
                 Community projectCommunity = communityService.create(null, Curator.curationContext());
               //} else {
-                // grab the linked projectCommunity by its handle
+                // grab the linked projectCommunity by its handle  NOTE: due to VSIM-82, this won't ever work, the projectCommunity handle won't point to the projectCommunity
                 //Community projectCommunity = communityService.create(null, Curator.curationContext());
               //}
 
@@ -376,9 +376,6 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               }
 
               // END: ADD LOGO to Community and Collections ///////////////////////////////////////////////////////////////////////////////
-
-
-
 
               // set the success flag and add a line to the result report
               // KEEP THIS AT THE END OF THE SCRIPT

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
@@ -135,6 +135,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
 
 
               String itemId = item.getHandle();
+              log.info("VSimProjectCurationTask: processing master item at handle: " + itemId);
               List<MetadataValue> mvDcTitle = itemService.getMetadata(item, "dc", "title", Item.ANY, Item.ANY);
               List<MetadataValue> mvDcDescriptionAbstract = itemService.getMetadata(item, "dc", "description", "abstract", Item.ANY);
               List<MetadataValue> mvDcDescription = itemService.getMetadata(item, "dc", "description", Item.ANY, Item.ANY);
@@ -172,6 +173,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               // -- disabled for now, hjp, the below is not fully cooked, it's just a start, do all of the above
               // if ( CollectionUtils.isNotEmpty(mvVsimRelationCommunity) ){
                 // create a new top level community for this project
+                log.info("VSimProjectCurationTask: creating new projectCommunity based on master item at handle: " + itemId);
                 Community projectCommunity = communityService.create(null, Curator.curationContext());
               //} else {
                 // grab the linked projectCommunity by its handle  NOTE: due to VSIM-82, this won't ever work, the projectCommunity handle won't point to the projectCommunity
@@ -212,12 +214,11 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               // snag the projectCommunityhandle, we'll need it
               String projectCommunityHandle = projectCommunity.getHandle();
 
-              // set the logo for the community, if possible, use projectCommunity.setLogo(Bitstream logo)
-
               // We need a DSpace group object for AuthZ purposes, for ContentCreators, to keep handy
               Group ContentCreatorsGroupObj = groupService.findByName(Curator.curationContext(), "Content Creators");
               Group AnonymousGroupObj = groupService.findByName(Curator.curationContext(), "Anonymous");
 
+              log.info("VSimProjectCurationTask: creating Administrators group for projectCommunity: " + projectCommunityHandle);
               // create the Administrators group we need
               Group projectCommunityAdminGroupObj = communityService.createAdministrators(Curator.curationContext(), projectCommunity);
 
@@ -231,6 +232,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               // if there is no link to the project models collection in this item's metadata, create a models collection in this project's TLC and add a link to the models collection as metadata for this project master item
               Collection projectCollModels = collectionService.create(Curator.curationContext(), projectCommunity);
               if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
+                log.info("VSimProjectCurationTask: adding links to projectCollModels at handle: " + projectCollModels.getHandle());
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue() + ": VSim Files");
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", null, null, "Files specific to VSim, including 3D models, narratives, and embedded resources (e.g., .vsim, .nar, .ere). For the " + mvDcTitle.get(0).getValue() + " project.");
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Files specific to VSim, including 3D models, narratives, and embedded resources (e.g., .vsim, .nar, .ere). For the " + mvDcTitle.get(0).getValue() + " project.");
@@ -240,6 +242,8 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
 
               }
+
+              log.info("VSimProjectCurationTask: creating Administators and Submitters groups for projectCollModels at handle: " + projectCollModels.getHandle());
 
               // create the Administrators and Submitters groups we need
               Group projectCollModelsAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollModels);
@@ -252,6 +256,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               groupService.update(Curator.curationContext(), projectCollModelsSubmittersGroupObj);
 
               // write this collection
+              log.info("VSimProjectCurationTask: writing changes to projectCollModels at handle: " + projectCollModels.getHandle());
               collectionService.update(Curator.curationContext(), projectCollModels);
               // add a link to this collection to the item
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY, projectCollModels.getHandle() );
@@ -260,6 +265,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               // if there is no link to the project archives collection in this item's metadata, create an archives collection in this project's TLC and add a link to the archives collection as metadata for this project master item
               Collection projectCollArchives = collectionService.create(Curator.curationContext(), projectCommunity);
               if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
+                log.info("VSimProjectCurationTask: adding links to projectCollArchives at handle: " + projectCollArchives.getHandle());
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue() + ": Project Archive");
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", null, null, "Multimedia files related to the project that provide context for the 3D model (e.g., .pdf, .jpg, .ppt, .csv, etc.). For the " + mvDcTitle.get(0).getValue() + " project.");
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Multimedia files related to the project that provide context for the 3D model (e.g., .pdf, .jpg, .ppt, .csv, etc.). For the " + mvDcTitle.get(0).getValue() + " project.");
@@ -268,6 +274,8 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 // ADD A LINK TO BACK TO THE PROJECT MASTER ITEM
                 collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
               }
+
+              log.info("VSimProjectCurationTask: creating Administators and Submitters groups for projectCollArchives at handle: " + projectCollArchives.getHandle());
 
               // create the Administrators and Submitters groups we need
               Group projectCollArchivesAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollArchives);
@@ -280,6 +288,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               groupService.update(Curator.curationContext(), projectCollArchivesSubmittersGroupObj);
 
               // write this collection
+              log.info("VSimProjectCurationTask: writing changes to projectCollArchives at handle: " + projectCollArchives.getHandle());
               collectionService.update(Curator.curationContext(), projectCollArchives);
               // add a link to this collection to the item
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY, projectCollArchives.getHandle() );
@@ -288,6 +297,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               // if there is no link to the project submissions collection in this item's metadata, create a submissions collection in this project's TLC and add a link to the submissions collection as metadata for this project master item
               Collection projectCollSubmissions = collectionService.create(Curator.curationContext(), projectCommunity);
               if ( CollectionUtils.isNotEmpty(mvDcTitle) ) {
+                log.info("VSimProjectCurationTask: adding links to projectCollSubmissions at handle: " + projectCollSubmissions.getHandle());
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "title", null, null, mvDcTitle.get(0).getValue() + ": User Submissions");
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", null, null, "Multimedia files submitted by users for sharing within the educational and research communities (e.g., narratives created for use in the classroom, or imagery and texts related to the 3D model that are in the public domain). For the " + mvDcTitle.get(0).getValue() + " project.");
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, MetadataSchema.DC_SCHEMA, "description", "abstract", null, "Multimedia files submitted by users for sharing within the educational and research communities (e.g., narratives created for use in the classroom, or imagery and texts related to the 3D model that are in the public domain). For the " + mvDcTitle.get(0).getValue() + " project.");
@@ -296,6 +306,8 @@ public class VSimProjectCurationTask extends AbstractCurationTask
                 // ADD A LINK TO BACK TO THE PROJECT MASTER ITEM
                 collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
               }
+
+              log.info("VSimProjectCurationTask: creating Administators and Submitters groups for projectCollSubmissions at handle: " + projectCollSubmissions.getHandle());
 
               // create the Administrators and Submitters groups we need
               Group projectCollSubmissionsAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollSubmissions);
@@ -308,6 +320,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               groupService.update(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj);
 
               // write this collection
+              log.info("VSimProjectCurationTask: writing changes to projectCollSubmissions at handle: " + projectCollSubmissions.getHandle());
               collectionService.update(Curator.curationContext(), projectCollSubmissions);
               // add a link to this collection to the item
               itemService.addMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY, projectCollSubmissions.getHandle() );
@@ -328,6 +341,8 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               // Loop through each bistream, find the logo, get the path, send that path to the addlogo method for all generated communities and collections
               // NOTE: this bakes in the assumption that this bitstream lives on the same server, and thus has a file path that this curation script can reference, which is not guaranteed
               // by DSpace. Still, good enough for now, as this assumption works for our current implementation.
+
+              log.info("VSimProjectCurationTask: adding logos for collections based on master item at handle: " + itemId);
 
               for (Bitstream bitstream : projectMasterBitstreams) {
                   String fileNameWithOutExt = FilenameUtils.removeExtension(bitstream.getName());

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -49,7 +49,7 @@ vsim = VSim Tasks
 
 # Group membership is defined using comma-separated lists of task names, one property per group
 curate.ui.taskgroup.general = profileformats, requiredmetadata, checklinks
-curate.ui.taskgroup.vsim = vsiminit, vsimaddmasteritemlink
+curate.ui.taskgroup.vsim = vsiminit, vsimitem, vsimaddmasteritemlink
 
 # Name of queue used when tasks queued in Admin UI
 curate.ui.queuename = admin_ui

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -18,6 +18,9 @@ plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MetadataV
 # add new tasks here (or in additional config files)
 
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimProjectCurationTask = vsiminit
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimProjectAddMasterItemLinkCurationTask = vsimaddmasteritemlink
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimItemCurationTask = vsimitem
+
 
 ## task queue implementation
 plugin.single.org.dspace.curate.TaskQueue = org.dspace.curate.FileTaskQueue
@@ -35,6 +38,9 @@ curate.ui.tasknames = profileformats = Profile Bitstream Formats
 curate.ui.tasknames = requiredmetadata = Check for Required Metadata
 curate.ui.tasknames = checklinks = Check Links in Metadata
 curate.ui.tasknames = vsiminit = Initialize VSim Project
+curate.ui.tasknames = vsimitem = Copy collection links to VSim Items
+curate.ui.tasknames = vsimaddmasteritemlink = Add Master Item Link to VSim Project Collections
+
 
 # Tasks may be organized into named groups which display together in UI drop-downs
 curate.ui.taskgroups = \
@@ -43,7 +49,7 @@ vsim = VSim Tasks
 
 # Group membership is defined using comma-separated lists of task names, one property per group
 curate.ui.taskgroup.general = profileformats, requiredmetadata, checklinks
-curate.ui.taskgroup.vsim = vsiminit
+curate.ui.taskgroup.vsim = vsiminit, vsimaddmasteritemlink
 
 # Name of queue used when tasks queued in Admin UI
 curate.ui.queuename = admin_ui
@@ -57,4 +63,3 @@ curate.ui.statusmessages = \
      1 = Fail, \
      2 = Skip, \
      other = Invalid Status
-


### PR DESCRIPTION
Added two new curation scripts: vsimitem and vsimaddmasteritemlink, to help copy links from the project master items to normal items, whenever they are archived; revised all scripts to be capable of running over entire collections of objects. Added info-level logging to all curation scripts, so we can keep track of what they're doing.