### PR TITLE
Vsim 134 create logged in users group (aka Contributor)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectCurationTask.java
@@ -216,7 +216,7 @@ public class VSimProjectCurationTask extends AbstractCurationTask
 
               // We need a DSpace group object for AuthZ purposes, for ContentCreators, to keep handy
               Group ContentCreatorsGroupObj = groupService.findByName(Curator.curationContext(), "Content Creators");
-              Group AnonymousGroupObj = groupService.findByName(Curator.curationContext(), "Anonymous");
+              Group ContributorGroupObj = groupService.findByName(Curator.curationContext(), "Contributor");
 
               log.info("VSimProjectCurationTask: creating Administrators group for projectCommunity: " + projectCommunityHandle);
               // create the Administrators group we need
@@ -313,9 +313,9 @@ public class VSimProjectCurationTask extends AbstractCurationTask
               Group projectCollSubmissionsAdminGroupObj = collectionService.createAdministrators(Curator.curationContext(), projectCollSubmissions);
               Group projectCollSubmissionsSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollSubmissions);
 
-              // add the ContentCreatorsGroupObj to the admin group we just created, and the AnonymousGroupObj to the submitters group we just created
+              // add the ContentCreatorsGroupObj to the admin group we just created, and the ContributorGroupObj to the submitters group we just created
               groupService.addMember(Curator.curationContext(), projectCollSubmissionsAdminGroupObj, ContentCreatorsGroupObj);
-              groupService.addMember(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj, AnonymousGroupObj);
+              groupService.addMember(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj, ContributorGroupObj);
               groupService.update(Curator.curationContext(), projectCollSubmissionsAdminGroupObj);
               groupService.update(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj);
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectFixPermissionsForSubmissionsCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectFixPermissionsForSubmissionsCurationTask.java
@@ -82,9 +82,9 @@ public class VSimProjectFixPermissionsForSubmissionsCurationTask extends Abstrac
 
           try {
 
-          // We need a DSpace group object for AuthZ purposes, for the Contributor group, to keep handy
+          // We need some DSpace group objects for AuthZ purposes, for the Contributor group, to keep handy
           Group ContributorGroupObj = groupService.findByName(Curator.curationContext(), "Contributor");
-
+          Group AnonymousGroupObj = groupService.findByName(Curator.curationContext(), "Anonymous");
           // *ONLY* KEEP GOING IF THIS ITEM IS A Collection, OTHERWISE *STOP*!!
           switch (dso.getType()) {
               case Constants.COLLECTION:
@@ -95,14 +95,14 @@ public class VSimProjectFixPermissionsForSubmissionsCurationTask extends Abstrac
                   break vsimInit;
                 }
 
-                // WARNING! DESTRUCTIVE! delete the current submitters group for this collection and replace it with a new one
-                collectionService.removeSubmitters(Curator.curationContext(), projectCollSubmissions);
-                // update the collectionService so that previous group is really really gone
-                collectionService.update(Curator.curationContext(), projectCollSubmissions);
-                Group projectCollSubmissionsSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollSubmissions);
+                // grab the current submitters group with the getSubmitters() on the collection object
+                Group projectCollSubmissionsSubmittersGroupObj = projectCollSubmissions.getSubmitters();
 
-                // add the ContributorGroupObj to the submitter group we just created
+                // remove the anonymous group from it
+                groupService.removeMember(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj, AnonymousGroupObj);
+                // then add contributor... 
                 groupService.addMember(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj, ContributorGroupObj);
+                // and then update to finalize these changes
                 groupService.update(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj);
 
                 // get the ID and name to this collection, so we can echo them to the logs

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectFixPermissionsForSubmissionsCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectFixPermissionsForSubmissionsCurationTask.java
@@ -97,6 +97,8 @@ public class VSimProjectFixPermissionsForSubmissionsCurationTask extends Abstrac
 
                 // WARNING! DESTRUCTIVE! delete the current submitters group for this collection and replace it with a new one
                 collectionService.removeSubmitters(Curator.curationContext(), projectCollSubmissions);
+                // update the collectionService so that previous group is really really gone
+                collectionService.update(Curator.curationContext(), projectCollSubmissions);
                 Group projectCollSubmissionsSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollSubmissions);
 
                 // add the ContributorGroupObj to the submitter group we just created

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectFixPermissionsForSubmissionsCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectFixPermissionsForSubmissionsCurationTask.java
@@ -1,0 +1,129 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+package org.dspace.ctask.general;
+
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.Collection;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
+
+import org.apache.log4j.Logger;
+
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+import org.dspace.content.MetadataValue;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.*;
+
+import java.sql.SQLException;
+import java.io.IOException;
+
+/**
+ * VSimProjectFixPermissionsForSubmissionsCurationTask is a task that ensures that the Contributor group has submit permissions for the Submissions folder of VSim projects
+ *
+ * @author hardyoyo
+ */
+
+@Distributive
+public class VSimProjectFixPermissionsForSubmissionsCurationTask extends AbstractCurationTask
+{
+/** log4j category */
+    private static final Logger log = Logger.getLogger(VSimProjectFixPermissionsForSubmissionsCurationTask.class);
+
+    protected CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService = ContentServiceFactory.getInstance().getCollectionService();
+    protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+    protected int status = Curator.CURATE_UNSET;
+    protected String result = null;
+
+    /**
+     * Perform the curation task upon passed DSO
+     *
+     * @param dso the DSpace object
+     * @throws IOException if IO error
+     * @throws SQLException if SQL error
+     */
+
+     @Override
+     public int perform(DSpaceObject dso) throws IOException
+     {
+          distribute(dso);
+          return Curator.CURATE_SUCCESS;
+     }
+
+     @Override
+     protected void performObject(DSpaceObject dso) throws IOException
+     {
+
+    int status = Curator.CURATE_SKIP;
+
+    // We need a DSpace group object for AuthZ purposes, for the Contributor group, to keep handy
+    Group ContributorGroupObj = groupService.findByName(Curator.curationContext(), "Contributor");
+
+    // set a breakpoint
+    vsimInit:
+
+          try {
+
+          // *ONLY* KEEP GOING IF THIS ITEM IS A Collection, OTHERWISE *STOP*!!
+          if ( !dso.getType()==Constants.COLLECTION ) {
+              break vsimInit;
+          }
+
+              projectCollSubmissions = (Collection)dso;
+
+              // only work if the collection's title ends with ' User Submissions'
+              if ( !projectCollSubmissions.getTitle().endsWith( ' User Submissions' ) ) {
+                break vsimInit;
+              }
+
+              // WARNING! DESTRUCTIVE! delete the current submitters group for this collection and replace it with a new one
+              collectionService.removeSubmitters(Curator.curationContext(), projectCollSubmissions)
+              Group projectCollSubmissionsSubmittersGroupObj = collectionService.createSubmitters(Curator.curationContext(), projectCollSubmissions);
+
+              // add the ContributorGroupObj to the submitter group we just created
+              groupService.addMember(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj, ContributorGroupObj);
+              groupService.update(Curator.curationContext(), projectCollSubmissionsSubmittersGroupObj);
+
+              // get the handle to this collection, so we can echo it to the logs
+              String collectionId = item.getHandle();
+              log.info("VSimProjectFixPermissionsForSubmissionsCurationTask: processing collection at handle: " + collectionId);
+
+              // Update the projectCollSubmissions collection, to save the changes we made above
+              collectionService.update(Curator.curationContext(), projectCollSubmissions);
+
+              // set the success flag and add a line to the result report
+              // KEEP THIS AT THE END OF THE SCRIPT
+
+              status = Curator.CURATE_SUCCESS;
+              result = "VSimProjectFixPermissionsForSubmissionsCurationTask completed based on " + itemId;
+
+            // catch any exceptions
+            } catch (AuthorizeException authE) {
+        		log.error("caught exception: " + authE);
+        		status = Curator.CURATE_FAIL;
+           	} catch (SQLException sqlE) {
+        		log.error("caught exception: " + sqlE);
+           	}
+
+
+              setResult(result);
+              report(result);
+
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -478,25 +478,6 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             groupService.update(context, adminGroup);
         }
 
-        // Check for ContentCreators group. If not found, create it
-        Group contentCreatorsGroup = groupService.findByName(context, "ContentCreators");
-        if(contentCreatorsGroup == null)
-        {
-            contentCreatorsGroup = groupService.create(context);
-            contentCreatorsGroup.setName("ContentCreators");
-            contentCreatorsGroup.setPermanent(true);
-            groupService.update(context, contentCreatorsGroup);
-        }
-
-        // Check for Contributor group. If not found, create it
-        Group contributorGroup = groupService.findByName(context, "Contributor");
-        if(contributorGroup == null)
-        {
-            contributorGroup = groupService.create(context);
-            contributorGroup.setName("ContentCreators");
-            contributorGroup.setPermanent(true);
-            groupService.update(context, contributorGroup);
-        }
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/eperson/GroupServiceImpl.java
@@ -477,6 +477,26 @@ public class GroupServiceImpl extends DSpaceObjectServiceImpl<Group> implements 
             adminGroup.setPermanent(true);
             groupService.update(context, adminGroup);
         }
+
+        // Check for ContentCreators group. If not found, create it
+        Group contentCreatorsGroup = groupService.findByName(context, "ContentCreators");
+        if(contentCreatorsGroup == null)
+        {
+            contentCreatorsGroup = groupService.create(context);
+            contentCreatorsGroup.setName("ContentCreators");
+            contentCreatorsGroup.setPermanent(true);
+            groupService.update(context, contentCreatorsGroup);
+        }
+
+        // Check for Contributor group. If not found, create it
+        Group contributorGroup = groupService.findByName(context, "Contributor");
+        if(contributorGroup == null)
+        {
+            contributorGroup = groupService.create(context);
+            contributorGroup.setName("ContentCreators");
+            contributorGroup.setPermanent(true);
+            groupService.update(context, contributorGroup);
+        }
     }
 
     @Override

--- a/dspace/config/modules/authentication-password.cfg
+++ b/dspace/config/modules/authentication-password.cfg
@@ -17,12 +17,12 @@
 # using the DSpace password system will automatically become members of
 # this group. This is useful if you want a group made up of all internal
 # authenticated users.
-# authentication-password.login.specialgroup = group-name
+authentication-password.login.specialgroup = Contributor
 
 ##### Password hashing algorithm #####
 
-# You may select any digest algorithm available through 
-# java.security.MessageDigest on your system.  At least MD2, MD5, SHA-1, 
-# SHA-256, SHA-384, and SHA-512 should be available, but you may have 
+# You may select any digest algorithm available through
+# java.security.MessageDigest on your system.  At least MD2, MD5, SHA-1,
+# SHA-256, SHA-384, and SHA-512 should be available, but you may have
 # installed others.  If not set, SHA-512 will be used.
 # authentication-password.digestAlgorithm = SHA-512

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -20,7 +20,7 @@ plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MetadataV
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimProjectCurationTask = vsiminit
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimProjectAddMasterItemLinkCurationTask = vsimaddmasteritemlink
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimItemCurationTask = vsimitem
-
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.VSimProjectFixPermissionsForSubmissionsCurationTask = vsimfixsubmissions
 
 ## task queue implementation
 plugin.single.org.dspace.curate.TaskQueue = org.dspace.curate.FileTaskQueue
@@ -39,6 +39,7 @@ curate.ui.tasknames = requiredmetadata = Check for Required Metadata
 curate.ui.tasknames = checklinks = Check Links in Metadata
 curate.ui.tasknames = vsiminit = Initialize VSim Project
 curate.ui.tasknames = vsimitem = Copy collection links to VSim Items
+curate.ui.tasknames = vsimfixsubmissions = Fix Permissions for VSim Submission Collections
 curate.ui.tasknames = vsimaddmasteritemlink = Add Master Item Link to VSim Project Collections
 
 
@@ -49,7 +50,7 @@ vsim = VSim Tasks
 
 # Group membership is defined using comma-separated lists of task names, one property per group
 curate.ui.taskgroup.general = profileformats, requiredmetadata, checklinks
-curate.ui.taskgroup.vsim = vsiminit, vsimitem, vsimaddmasteritemlink
+curate.ui.taskgroup.vsim = vsimfixsubmissions, vsiminit, vsimitem, vsimaddmasteritemlink
 
 # Name of queue used when tasks queued in Admin UI
 curate.ui.queuename = admin_ui


### PR DESCRIPTION
This PR creates a new Contributor "special group" and assigns to that group any users who successfully logs in. It also creates a curation task to remove the anonymous group from any User Submissions collection and replace it with the Contributor group. Tested on test-vsim, confirmed working.