### PR TITLE
[VSIM-142] prevent VSim item curation task from making duplicates

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -124,15 +124,15 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
                     //before we add the relation values for these collections to this item, first remove all existing relations from this item
-                    while( itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY) !=null ) {
+                    while( itemService.getMetadataByMetadataString(item, "vsim.relation.models") != null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
                     }
-                    while( itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY) !=null ) {
+                    while( itemService.getMetadataByMetadataString(item, "vsim.relation.archives") != null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
                     }
-                    while( itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY) !=null ) {
+                    while( itemService.getMetadataByMetadataString(item, "vsim.relation.submissions") != null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
                     }

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -127,6 +127,7 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationModels);
                     itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationArchives);
                     itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationSubmissions);
+                    itemService.update(Curator.curationContext(), item);
 
                     // set the relation values to the projectMaster values gathered above
                     log.info("VSimItemCurationTask:  - adding vsim.relation.models: " + mvVsimMasterRelationModels.get(0).getValue());

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -126,15 +126,16 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     //before we add the relation values for these collections to this item, first remove all existing relations from this item
                     while( itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY) !=null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
+                      itemService.update(Curator.curationContext(), item);
                     }
                     while( itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY) !=null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
+                      itemService.update(Curator.curationContext(), item);
                     }
                     while( itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY) !=null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
-                    }
-
                       itemService.update(Curator.curationContext(), item);
+                    }
 
 
                     // set the relation values to the projectMaster values gathered above

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -81,7 +81,7 @@ public class VSimItemCurationTask extends AbstractCurationTask
         projectMasterCollectionHandle = "20.500.11991/1009"; // <-- that better be a collection object on that handle
       }
 
-    vsimItem:
+    vsimInit:
           try {
 
             switch (dso.getType()) {
@@ -96,7 +96,7 @@ public class VSimItemCurationTask extends AbstractCurationTask
 
                 // IF THIS ITEM IS A PROJECT MASTER, *STOP*!! OTHERWISE, CONTINUE...
                 if (itemService.isIn(item, projectMastersCollection)) {
-                    break vsimItem;
+                    break vsimInit;
                 }
 
                     log.info("VSimItemCurationTask: processing item at handle: " + itemId);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -124,17 +124,23 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
                     //before we add the relation values for these collections to this item, first remove all existing relations from this item
-                    while( itemService.getMetadataByMetadataString(item, "vsim.relation.models") != null ) {
+                    List<MetadataValue> mvExistingItemRelationModels = itemService.getMetadataByMetadataString(item, "vsim.relation.models");
+                    while( mvExistingItemRelationModels.size() != 0 ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
+                      item = Curator.curationContext().reloadEntity(item);
                     }
-                    while( itemService.getMetadataByMetadataString(item, "vsim.relation.archives") != null ) {
+                    List<MetadataValue> mvExistingItemRelationArchives = itemService.getMetadataByMetadataString(item, "vsim.relation.archives");
+                    while( mvExistingItemRelationArchives.size() != 0 ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
+                      item = Curator.curationContext().reloadEntity(item);
                     }
-                    while( itemService.getMetadataByMetadataString(item, "vsim.relation.submissions") != null ) {
+                    List<MetadataValue> mvExistingItemRelationSubmissions = itemService.getMetadataByMetadataString(item, "vsim.relation.submissions");
+                    while( mvExistingItemRelationSubmissions.size() != 0 ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
+                      item = Curator.curationContext().reloadEntity(item);
                     }
 
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -6,11 +6,6 @@
  * http://www.dspace.org/license/
  */
 
- /*
-TODO: refactor this script to follow this example:
-https://github.com/DSpace/DSpace/blob/ea642d6c9289d96b37b5de3bb7a4863ec48eaa9c/dspace-api/src/main/java/org/dspace/ctask/general/ProfileFormats.java
-*/
-
 package org.dspace.ctask.general;
 
 import java.util.List;
@@ -106,7 +101,7 @@ public class VSimItemCurationTask extends AbstractCurationTask
 
                     log.info("VSimItemCurationTask: processing item at handle: " + itemId);
 
-                    // TODO: find the corresponding project master item for all items in this collection
+                    // find the corresponding project master item for all items in this collection
                     // first, grab the collection object for this item
                     List<Collection> thisItemCollection = itemService.getCollectionsNotLinked(Curator.curationContext(), item);
 
@@ -128,6 +123,10 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationArchives = itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY);
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
+                    //before we add the relation values for these collections to this item, first remove any existing relations from this item
+                    itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationModels);
+                    itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationArchives);
+                    itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationSubmissions);
 
                     // set the relation values to the projectMaster values gathered above
                     log.info("VSimItemCurationTask:  - adding vsim.relation.models: " + mvVsimMasterRelationModels.get(0).getValue());

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -123,11 +123,19 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationArchives = itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY);
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
-                    //before we add the relation values for these collections to this item, first remove any existing relations from this item
-                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
-                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
-                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
-                    itemService.update(Curator.curationContext(), item);
+                    //before we add the relation values for these collections to this item, first remove all existing relations from this item
+                    while( itemService.getMetadata(projectMasterItem, "vsim", "relation", "models", Item.ANY) !=null ) {
+                      itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
+                    }
+                    while( itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY) !=null ) {
+                      itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
+                    }
+                    while( itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY) !=null ) {
+                      itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
+                    }
+
+                      itemService.update(Curator.curationContext(), item);
+
 
                     // set the relation values to the projectMaster values gathered above
                     log.info("VSimItemCurationTask:  - adding vsim.relation.models: " + mvVsimMasterRelationModels.get(0).getValue());

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -124,13 +124,13 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
                     //before we add the relation values for these collections to this item, first remove all existing relations from this item
-                    while( itemService.getMetadata(projectMasterItem, "vsim", "relation", "models", Item.ANY) !=null ) {
+                    while( itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY) !=null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
                     }
-                    while( itemService.getMetadata(projectMasterItem, "vsim", "relation", "archives", Item.ANY) !=null ) {
+                    while( itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY) !=null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
                     }
-                    while( itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY) !=null ) {
+                    while( itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY) !=null ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
                     }
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -124,9 +124,9 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
                     //before we add the relation values for these collections to this item, first remove any existing relations from this item
-                    itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationModels);
-                    itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationArchives);
-                    itemService.removeMetadataValues(Curator.curationContext(), item, mvVsimMasterRelationSubmissions);
+                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY)
+                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY)
+                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY)
                     itemService.update(Curator.curationContext(), item);
 
                     // set the relation values to the projectMaster values gathered above

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -129,18 +129,21 @@ public class VSimItemCurationTask extends AbstractCurationTask
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
                       item = Curator.curationContext().reloadEntity(item);
+                      mvExistingItemRelationModels = itemService.getMetadataByMetadataString(item, "vsim.relation.models");
                     }
                     List<MetadataValue> mvExistingItemRelationArchives = itemService.getMetadataByMetadataString(item, "vsim.relation.archives");
                     while( mvExistingItemRelationArchives.size() != 0 ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
                       item = Curator.curationContext().reloadEntity(item);
+                      mvExistingItemRelationArchives = itemService.getMetadataByMetadataString(item, "vsim.relation.archives");
                     }
                     List<MetadataValue> mvExistingItemRelationSubmissions = itemService.getMetadataByMetadataString(item, "vsim.relation.submissions");
                     while( mvExistingItemRelationSubmissions.size() != 0 ) {
                       itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
                       itemService.update(Curator.curationContext(), item);
                       item = Curator.curationContext().reloadEntity(item);
+                      mvExistingItemRelationSubmissions = itemService.getMetadataByMetadataString(item, "vsim.relation.submissions");
                     }
 
 

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimItemCurationTask.java
@@ -124,9 +124,9 @@ public class VSimItemCurationTask extends AbstractCurationTask
                     List<MetadataValue> mvVsimMasterRelationSubmissions = itemService.getMetadata(projectMasterItem, "vsim", "relation", "submissions", Item.ANY);
 
                     //before we add the relation values for these collections to this item, first remove any existing relations from this item
-                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY)
-                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY)
-                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY)
+                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "models", Item.ANY);
+                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "archives", Item.ANY);
+                    itemService.clearMetadata(Curator.curationContext(), item, "vsim", "relation", "submissions", Item.ANY);
                     itemService.update(Curator.curationContext(), item);
 
                     // set the relation values to the projectMaster values gathered above

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -124,26 +124,26 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
                       Collection projectCollSubmissions = (Collection) projectCollSubmissionsDSO;
 
                       // first delete any existing relations before we add these
-                      List<MetadataValue> mvExistingVsimRelationModels = collectionService.getMetadata(projectCollModels, "vsim", "relation", "models", Item.ANY);
-                      while( mvExistingVsimRelationModels.size() != 0 ) {
+                      List<MetadataValue> mvExistingVsimRelationModelsProjectMaster = collectionService.getMetadata(projectCollModels, "vsim", "relation", "projectMaster", Item.ANY);
+                      while( mvExistingVsimRelationModelsProjectMaster.size() != 0 ) {
                         collectionService.clearMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "models", Item.ANY);
                         collectionService.update(Curator.curationContext(), projectCollModels);
                         projectCollModels = Curator.curationContext().reloadEntity(projectCollModels);
-                        mvExistingVsimRelationModels = collectionService.getMetadataByMetadataString(projectCollModels, "vsim.relation.models");
+                        mvExistingVsimRelationModelsProjectMaster = collectionService.getMetadataByMetadataString(projectCollModels, "vsim.relation.projectMaster");
                       }
-                      List<MetadataValue> mvExistingVsimRelationArchives = collectionService.getMetadata(projectCollArchives, "vsim", "relation", "archives", Item.ANY);
-                      while( mvExistingVsimRelationArchives.size() != 0 ) {
+                      List<MetadataValue> mvExistingVsimRelationArchivesProjectMaster = collectionService.getMetadata(projectCollArchives, "vsim", "relation", "projectMaster", Item.ANY);
+                      while( mvExistingVsimRelationArchivesProjectMaster.size() != 0 ) {
                         collectionService.clearMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "archives", Item.ANY);
                         collectionService.update(Curator.curationContext(), projectCollArchives);
                         projectCollModels = Curator.curationContext().reloadEntity(projectCollArchives);
-                        mvExistingVsimRelationArchives = collectionService.getMetadataByMetadataString(projectCollArchives, "vsim.relation.archives");
+                        mvExistingVsimRelationArchivesProjectMaster = collectionService.getMetadataByMetadataString(projectCollArchives, "vsim.relation.projectMaster");
                       }
-                      List<MetadataValue> mvExistingVsimRelationSubmissions = collectionService.getMetadata(projectCollSubmissions, "vsim", "relation", "submissions", Item.ANY);
-                      while( mvExistingVsimRelationSubmissions.size() != 0 ) {
+                      List<MetadataValue> mvExistingVsimRelationSubmissionsProjectMaster = collectionService.getMetadata(projectCollSubmissions, "vsim", "relation", "projectMaster", Item.ANY);
+                      while( mvExistingVsimRelationSubmissionsProjectMaster.size() != 0 ) {
                         collectionService.clearMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "submissions", Item.ANY);
                         collectionService.update(Curator.curationContext(), projectCollSubmissions);
                         projectCollModels = Curator.curationContext().reloadEntity(projectCollSubmissions);
-                        mvExistingVsimRelationSubmissions = collectionService.getMetadataByMetadataString(projectCollSubmissions, "vsim.relation.submissions");
+                        mvExistingVsimRelationSubmissionsProjectMaster = collectionService.getMetadataByMetadataString(projectCollSubmissions, "vsim.relation.projectMaster");
                       }
 
                       // set the link back to the project master item for each container object we grabbed above

--- a/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/VSimProjectAddMasterItemLinkCurationTask.java
@@ -16,6 +16,7 @@ import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.Collection;
 import org.dspace.curate.AbstractCurationTask;
+import org.dspace.core.Constants;
 import org.dspace.curate.Curator;
 import org.dspace.curate.Distributive;
 
@@ -65,7 +66,7 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
      }
 
      @Override
-     protected void performItem(Item item) throws IOException
+     protected void performObject(DSpaceObject dso) throws IOException
      {
 
     int status = Curator.CURATE_SKIP;
@@ -86,57 +87,90 @@ public class VSimProjectAddMasterItemLinkCurationTask extends AbstractCurationTa
 
           try {
 
-          DSpaceObject projectMastersDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterCollectionHandle);
-          Collection projectMastersCollection = (Collection) projectMastersDSO;
+              switch (dso.getType()) {
+                case Constants.ITEM:
+                  Item item = (Item) dso;
 
-          // *ONLY* KEEP GOING IF THIS ITEM IS A PROJECT MASTER, OTHERWISE *STOP*!!
-          if (!itemService.isIn(item, projectMastersCollection)) {
-              break vsimInit;
-          }
+                  DSpaceObject projectMastersDSO = handleService.resolveToObject(Curator.curationContext(), projectMasterCollectionHandle);
+                  Collection projectMastersCollection = (Collection) projectMastersDSO;
 
-              // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
-              // use the usual list stuff to manage multiple values
+                  // *ONLY* KEEP GOING IF THIS ITEM IS A PROJECT MASTER, OTHERWISE *STOP*!!
+                  if (!itemService.isIn(item, projectMastersCollection)) {
+                      break vsimInit;
+                  }
 
-              // get the handle to this master item, we'll need it
-              String itemId = item.getHandle();
-              log.info("VSimProjectAddMasterItemLinkCurationTask: processing master item at handle: " + itemId);
+                      // Get All requried MetadataValues, all are returned as lists, use .get(0).getValue() to return the first value, like strings,
+                      // use the usual list stuff to manage multiple values
+
+                      // get the handle to this master item, we'll need it
+                      String itemId = item.getHandle();
+                      log.info("VSimProjectAddMasterItemLinkCurationTask: processing master item at handle: " + itemId);
 
 
-              // the following are used to find the containers to which we need to add the itemId
-              List<MetadataValue> mvVsimRelationModels = itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY);
-              List<MetadataValue> mvVsimRelationArchives = itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY);
-              List<MetadataValue> mvVsimRelationSubmissions = itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY);
+                      // the following are used to find the containers to which we need to add the itemId
+                      List<MetadataValue> mvVsimRelationModels = itemService.getMetadata(item, "vsim", "relation", "models", Item.ANY);
+                      List<MetadataValue> mvVsimRelationArchives = itemService.getMetadata(item, "vsim", "relation", "archives", Item.ANY);
+                      List<MetadataValue> mvVsimRelationSubmissions = itemService.getMetadata(item, "vsim", "relation", "submissions", Item.ANY);
 
-              // grab each container object using the handles above
-              // -- the HandleService has resolveToObject(Context context, String handle) which goes from handle to dso
-              // -- NOTE: this is a generic dso, not a typed dso (i.e. not a community or collection object)
-              // -- just look at the code starting around line 103, there's an example there
-              DSpaceObject projectCollModelsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationModels.get(0).getValue());
-              Collection projectCollModels = (Collection) projectCollModelsDSO;
-              DSpaceObject projectCollArchivesDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationArchives.get(0).getValue());
-              Collection projectCollArchives = (Collection) projectCollArchivesDSO;
-              DSpaceObject projectCollSubmissionsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationSubmissions.get(0).getValue());
-              Collection projectCollSubmissions = (Collection) projectCollSubmissionsDSO;
+                      // grab each container object using the handles above
+                      // -- the HandleService has resolveToObject(Context context, String handle) which goes from handle to dso
+                      // -- NOTE: this is a generic dso, not a typed dso (i.e. not a community or collection object)
+                      // -- just look at the code starting around line 103, there's an example there
+                      DSpaceObject projectCollModelsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationModels.get(0).getValue());
+                      Collection projectCollModels = (Collection) projectCollModelsDSO;
+                      DSpaceObject projectCollArchivesDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationArchives.get(0).getValue());
+                      Collection projectCollArchives = (Collection) projectCollArchivesDSO;
+                      DSpaceObject projectCollSubmissionsDSO = handleService.resolveToObject(Curator.curationContext(), mvVsimRelationSubmissions.get(0).getValue());
+                      Collection projectCollSubmissions = (Collection) projectCollSubmissionsDSO;
 
-              // set the link back to the project master item for each container object we grabbed above
-              log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollModels at handle: " + projectCollModels.getHandle());
-              collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
-              log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollArchives at handle: " + projectCollArchives.getHandle());
-              collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
-              log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollSubmissions at handle: " + projectCollSubmissions.getHandle());
-              collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
+                      // first delete any existing relations before we add these
+                      List<MetadataValue> mvExistingVsimRelationModels = collectionService.getMetadata(projectCollModels, "vsim", "relation", "models", Item.ANY);
+                      while( mvExistingVsimRelationModels.size() != 0 ) {
+                        collectionService.clearMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "models", Item.ANY);
+                        collectionService.update(Curator.curationContext(), projectCollModels);
+                        projectCollModels = Curator.curationContext().reloadEntity(projectCollModels);
+                        mvExistingVsimRelationModels = collectionService.getMetadataByMetadataString(projectCollModels, "vsim.relation.models");
+                      }
+                      List<MetadataValue> mvExistingVsimRelationArchives = collectionService.getMetadata(projectCollArchives, "vsim", "relation", "archives", Item.ANY);
+                      while( mvExistingVsimRelationArchives.size() != 0 ) {
+                        collectionService.clearMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "archives", Item.ANY);
+                        collectionService.update(Curator.curationContext(), projectCollArchives);
+                        projectCollModels = Curator.curationContext().reloadEntity(projectCollArchives);
+                        mvExistingVsimRelationArchives = collectionService.getMetadataByMetadataString(projectCollArchives, "vsim.relation.archives");
+                      }
+                      List<MetadataValue> mvExistingVsimRelationSubmissions = collectionService.getMetadata(projectCollSubmissions, "vsim", "relation", "submissions", Item.ANY);
+                      while( mvExistingVsimRelationSubmissions.size() != 0 ) {
+                        collectionService.clearMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "submissions", Item.ANY);
+                        collectionService.update(Curator.curationContext(), projectCollSubmissions);
+                        projectCollModels = Curator.curationContext().reloadEntity(projectCollSubmissions);
+                        mvExistingVsimRelationSubmissions = collectionService.getMetadataByMetadataString(projectCollSubmissions, "vsim.relation.submissions");
+                      }
 
-              // now write all that metadata with a set of updates
-              log.info("VSimProjectAddMasterItemLinkCurationTask: Writing changes to all three project collections for master item at handle: " + itemId);
-              collectionService.update(Curator.curationContext(), projectCollModels);
-              collectionService.update(Curator.curationContext(), projectCollArchives);
-              collectionService.update(Curator.curationContext(), projectCollSubmissions);
+                      // set the link back to the project master item for each container object we grabbed above
+                      log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollModels at handle: " + projectCollModels.getHandle());
+                      collectionService.addMetadata(Curator.curationContext(), projectCollModels, "vsim", "relation", "projectMaster", null, itemId);
+                      log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollArchives at handle: " + projectCollArchives.getHandle());
+                      collectionService.addMetadata(Curator.curationContext(), projectCollArchives, "vsim", "relation", "projectMaster", null, itemId);
+                      log.info("VSimProjectAddMasterItemLinkCurationTask:  - adding vsim.relation.projectMaster to projectCollSubmissions at handle: " + projectCollSubmissions.getHandle());
+                      collectionService.addMetadata(Curator.curationContext(), projectCollSubmissions, "vsim", "relation", "projectMaster", null, itemId);
 
-              // set the success flag and add a line to the result report
-              // KEEP THIS AT THE END OF THE SCRIPT
+                      // now write all that metadata with a set of updates
+                      log.info("VSimProjectAddMasterItemLinkCurationTask: Writing changes to all three project collections for master item at handle: " + itemId);
+                      collectionService.update(Curator.curationContext(), projectCollModels);
+                      collectionService.update(Curator.curationContext(), projectCollArchives);
+                      collectionService.update(Curator.curationContext(), projectCollSubmissions);
 
-              status = Curator.CURATE_SUCCESS;
-              result = "VSim Project Master item links intialized based on " + itemId;
+                      // set the success flag and add a line to the result report
+                      // KEEP THIS AT THE END OF THE SCRIPT
+
+                      status = Curator.CURATE_SUCCESS;
+                      result = "VSim Project Master item links intialized based on " + itemId;
+                      break;
+
+                default: status = Curator.CURATE_SUCCESS;
+                break;
+
+              }
 
             // catch any exceptions
             } catch (AuthorizeException authE) {


### PR DESCRIPTION
This pull request includes updates to both the VSimItemCurationTask and the VSimProjectAddMasterItemLinkCurationTask, to make them better behaved:

- they are properly recursive now, and 
- they delete existing vsim.relation links before creating new ones

This PR fixes VSIM-142, and is related to VSIM-138.