### PR TITLE
borrow the fix from https://github.com/DSpace/DSpace/pull/2304

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ script:
   #        -Dmirage2.on=true => Build Mirage2
   #        -Dmirage2.deps.included=false => Don't include Mirage2 build dependencies (We installed them in before_install)
   #        -P !assembly => SKIP the actual building of [src]/dspace/dspace-installer (as it can be memory intensive)
-  - "cd dspace && mvn package -Dmirage2.on=true -Dmirage2.deps.included=false -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2"
+  - "cd dspace && mvn package -Dmirage2.on=true -Dmirage2.deps.included=true -P !assembly -B -V -Dsurefire.rerunFailingTestsCount=2"

--- a/dspace/modules/xmlui-mirage2/pom.xml
+++ b/dspace/modules/xmlui-mirage2/pom.xml
@@ -499,7 +499,12 @@
     </profiles>
 
     <dependencies>
-
+        <dependency>
+    		   <groupId>rubygems</groupId>
+    		   <artifactId>rb-inotify</artifactId>
+    		   <version>0.9.10</version>
+    		   <type>gem</type>
+    		</dependency>
         <dependency>
             <groupId>org.dspace</groupId>
             <artifactId>dspace-xmlui-mirage2</artifactId>


### PR DESCRIPTION
DSpace cannot currently compile without the addition made by https://github.com/DSpace/DSpace/pull/2304

This Pull Reuest borrows that change, so that we can compile VSim.