### PR TITLE
VSIM-145: use search_text instead of fullrecord for df in Solrconfig

### DIFF
--- a/dspace/solr/vsim_search/conf/solrconfig.xml
+++ b/dspace/solr/vsim_search/conf/solrconfig.xml
@@ -813,8 +813,8 @@
        <str name="defType">edismax</str>
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
-       <str name="df">fullrecord</str>
-       <str name="qf">dc.type^50 title^25 fullrecord</str>
+       <str name="df">search_text</str>
+       <str name="qf">dc.type^50 title^25 search_text</str>
        <!-- suggestion from Parinita (see VSIM-91)  q=VSimProjectMaster&qf=dc.type^2 -->
        <str name="bq">dc.type:VSimProjectMaster^100</str>
      </lst>

--- a/dspace/solr/vsim_search/conf/solrconfig.xml
+++ b/dspace/solr/vsim_search/conf/solrconfig.xml
@@ -817,6 +817,7 @@
        <str name="qf">dc.type^50 title^25 search_text</str>
        <!-- suggestion from Parinita (see VSIM-91)  q=VSimProjectMaster&qf=dc.type^2 -->
        <str name="bq">dc.type:VSimProjectMaster^100</str>
+       <str name="bq">dc.type:Model^80</str>
      </lst>
       <arr name="last-components">
           <str>spellcheck</str>


### PR DESCRIPTION
This PR reverts a mistake in #PR144, adding back full text searching.