### PR TITLE
Set JDK for Travis-CI to OpenJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 sudo: false
 
 env:


### PR DESCRIPTION
This should get our Travis-CI builds back to working.